### PR TITLE
compatible with older drush and drush 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 The base ZIP preprocessor can be called as a drush script (see `drush help islandora_paged_content_pdf_batch_preprocess` for additional parameters):
 
+Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
+The `target` option requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip
+
+Drush 7 and above:
+
+`drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --scan_target=/path/to/archive.zip --content-model=islandora:bookCModel --parent=islandora:bookCollection`
+
+Drush 6 and below:
+
 `drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --target=/path/to/archive.zip --content-model=islandora:bookCModel --parent=islandora:bookCollection`
 
 This will populate the queue (stored in the Drupal database) with base entries.

--- a/islandora_paged_content_pdf_batch.drush.inc
+++ b/islandora_paged_content_pdf_batch.drush.inc
@@ -22,10 +22,6 @@ function islandora_paged_content_pdf_batch_drush_command() {
         'description' => dt('The target type: zip or directory. Defaults to zip.'),
         'value' => 'optional',
       ),
-      'target' => array(
-        'description' => dt('The path to the ZIP file or directory to scan.'),
-        'required' => TRUE,
-      ),
       'text' => array(
         'description' => dt('One of the following options: "extract" to pull the text out of the PDF, "ocr" to run OCR against the PDF or "none". Defaults to "extract"'),
         'value' => 'optional',
@@ -81,10 +77,22 @@ function islandora_paged_content_pdf_batch_drush_command() {
       ),
     ),
     'examples' => array(
-      'drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --target=/path/to/archive.zip --content_model=islandora:bookCModel --parent=islandora:bookCollection' => t('Preprocessing paged content.'),
+      'drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --scan_target=/path/to/archive.zip --content_model=islandora:bookCModel --parent=islandora:bookCollection' => t('Preprocessing paged content.'),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
+  if (DRUSH_VERSION >= 7) {
+    $items['islandora_paged_content_pdf_batch_preprocess']['options']['scan_target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
+  else {
+    $items['islandora_paged_content_pdf_batch_preprocess']['options']['target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
   return $items;
 }
 
@@ -96,7 +104,12 @@ function drush_islandora_paged_content_pdf_batch_preprocess_validate() {
   module_load_include('inc', 'islandora_batch', 'includes/utilities');
   $type = drush_get_option('type', 'zip');
   // See if the target specified exists.
-  $target = drush_get_option('target');
+  if (DRUSH_VERSION >= 7) {
+    $target = drush_get_option('scan_target');
+  }
+  else {
+    $target = drush_get_option('target');
+  }
   if (file_exists($target)) {
     if ($type == 'zip') {
       $allowed_zips = array(
@@ -141,7 +154,7 @@ function drush_islandora_paged_content_pdf_batch_preprocess_validate() {
     module_load_include('inc', 'islandora_paged_content_pdf_batch', 'includes/utilities');
     $valid_languages = islandora_paged_content_pdf_batch_available_languages();
     if (!in_array($language, $valid_languages)) {
-      return drush_set_error('Invalid language entered', dt('The specified language, !language, is not valid. Languages available are: @lang.', array(
+      return drush_set_error('Invalid language entered', dt('The specified language, !language, is not valid. Languages available are: @lang.  If list is empty, please refresh the Islandora OCR module languages.', array(
         '!language' => $language,
         '@lang' => implode(', ', $valid_languages),
       )));
@@ -193,7 +206,7 @@ function drush_islandora_paged_content_pdf_batch_preprocess() {
   $connection = islandora_get_tuque_connection();
   $parameters = array(
     'type' => drush_get_option('type', 'zip'),
-    'target' => drush_get_option('target'),
+    'target' => DRUSH_VERSION >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'content_model' => drush_get_option('content_model'),
     'parent' => drush_get_option('parent'),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', FEDORA_RELS_EXT_URI),


### PR DESCRIPTION
Same as previous request, but without changing "--namespace" requirements.

It allows users of older drush to continue using their same workflow.  However, newer drush reserved the keyword "--target", so the command uses "--scan-target".