### PR TITLE
Fix drush command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ The `target` option requires the full path to your archive from root directory. 
 
 Drush 7 and above:
 
-`drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --scan_target=/path/to/archive.zip --content-model=islandora:bookCModel --parent=islandora:bookCollection`
+`drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --scan_target=/path/to/archive.zip --content_model=islandora:bookCModel --parent=islandora:bookCollection`
 
 Drush 6 and below:
 
-`drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --target=/path/to/archive.zip --content-model=islandora:bookCModel --parent=islandora:bookCollection`
+`drush -v -u 1 --uri=http://localhost islandora_paged_content_pdf_batch_preprocess --target=/path/to/archive.zip --content_model=islandora:bookCModel --parent=islandora:bookCollection`
 
 This will populate the queue (stored in the Drupal database) with base entries.
 


### PR DESCRIPTION
changed --content-model to --content_model ... original lines incorrect.